### PR TITLE
bug fix googleController

### DIFF
--- a/src/controllers/googleController.ts
+++ b/src/controllers/googleController.ts
@@ -32,7 +32,7 @@ export const handleGoogleLogin = async (
 
     // Verify the ID token with Google
     const ticket = await oAuth2Client.verifyIdToken({
-      idToken: idToken, 
+      idToken: idToken,
       audience: process.env.CLIENT_ID,
     });
 
@@ -62,6 +62,11 @@ export const handleGoogleLogin = async (
         name,
         email,
       });
+      // Something went wrong here
+      if (response.status !== 201) {
+        res.status(400).json({ error: `Invalid format` });
+        return;
+      }
       user_id = response.data.user_id;
     }
 


### PR DESCRIPTION
In the live demo, the response we saw on the console when Kevin tried to log in with a gmail account was a 500 server error. However, this should be a 400 Bad Request. I know that currently we are dealing with Log In/Register as the same thing, but I think in the future, we could just leave all the handling to the users POST route itself, since it returns a 409 Conflict if the user already exists, which we could display to the users on the frontend.